### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -51,7 +51,7 @@
                1. "," taken off from the \inlinecite
     * 2009.06.02
           o spr-mp-sola.bst and spr-mp-sola-cnd.bst:
-               1. doi links out to http://dx.doi.org (using with \usepackage{hyperref}])
+               1. doi links out to https://doi.org (using with \usepackage{hyperref}])
     * 2008.06.18
           o natbib option added to spr-sola-addons.sty. Use this option to load a natbib package. (\usepackage[optionalrh,natbib]{spr-sola-addons})
     * 2008.04.23

--- a/bst/spr-mp-sola.bst
+++ b/bst/spr-mp-sola.bst
@@ -24,7 +24,7 @@
 % 2013-12-19 -- added fields: arxiv, adsurl.
 %               Striping "http://arxiv.org/abs/" from begin of arxiv.
 %               Striping "http://adsabs.harvard.edu/" + "abs/" from begin of adsurl.
-%               Striping "http://dx.doi.org/" from begin of doi.
+%               Striping "https://doi.org/" from begin of doi.
 %               Sorting takes into account initials, not names.
 % 2014-01-28 -- escaping "%" in url and adsurl fields.
 % 2014-02-13 -- removed last page from output.
@@ -2582,7 +2582,7 @@ FUNCTION {begin.bib}
     { preamble$ write$ newline$ }
   if$
   write.preambule
-  "\ifx\doiurl    \undefined \def\doiurl#1{\href{http://dx.doi.org/#1}{\textsf{DOI}}}\fi" write$ newline$
+  "\ifx\doiurl    \undefined \def\doiurl#1{\href{https://doi.org/#1}{\textsf{DOI}}}\fi" write$ newline$
   "\ifx\arxivurl  \undefined \def\arxivurl#1{\href{http://arxiv.org/abs/#1}{\textsf{arXiv}}}\fi" write$ newline$
   "\ifx\adsurl    \undefined \def\adsurl#1{\href{http://adsabs.harvard.edu/abs/#1}{\textsf{ADS}}}\fi" write$ newline$
   "\ifx\botherref \undefined \def\botherref#1{}\fi" write$ newline$

--- a/example/sola_example_6.bbl
+++ b/example/sola_example_6.bbl
@@ -27,7 +27,7 @@
 \ifx\binstitute  \undefined \def\binstitute#1{#1}\fi
 \ifx\bpublisher  \undefined \def\bpublisher#1{#1}\fi
 \ifx\doiurl    \undefined
-  \def\doiurl#1{\href{http://dx.doi.org/#1}{\textsf{DOI}}}\fi
+  \def\doiurl#1{\href{https://doi.org/#1}{\textsf{DOI}}}\fi
 \ifx\arxivurl  \undefined
   \def\arxivurl#1{\href{http://arxiv.org/abs/#1}{\textsf{arXiv}}}\fi
 \ifx\adsurl    \undefined


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but nonetheless, I'd like to suggest to hereby update all static DOI links and any code that hyperlinks DOIs. It that acceptable as a PR, or shall I also email `latex-support@vtex.lt`?

Also, [all your other repos](https://github.com/search?o=desc&q=org%3Avtex-soft+dx.doi&s=indexed&type=Code) could benefit from the same update. 

Cheers!